### PR TITLE
Implement parsing of multiple js code blocks in a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Snippets configuration is done in JavaScript with configuration notes looking li
 ];
 ```
 
+A configuration note can contain arbitrary other markdown content. All javascript code blocks are parsed. This allows for easy organisation of configuration files into e.g. sections.
+
 ### Trigger
 
 Type: `string`  


### PR DESCRIPTION
This change allows multiple javascript code blocks in a single configuration note. The feature is handy for structuring a single bigger configuration note. Regulare expressions are used to extract the javascript code blocks.